### PR TITLE
Added transparency to column when including 'nesting' class on td

### DIFF
--- a/src/components/_colors.scss
+++ b/src/components/_colors.scss
@@ -5,6 +5,7 @@
 
   @for $i from 1 through $total-colors {
     &.bar tbody tr:nth-of-type(#{ $total-colors }n + #{ $i }) td,
+
     &.bar.multiple tbody tr td:nth-of-type(#{ $total-colors }n + #{ $i }),
     &.column tbody tr:nth-of-type(#{ $total-colors }n + #{ $i }) td,
     &.column.multiple tbody tr td:nth-of-type(#{ $total-colors }n + #{ $i }),
@@ -19,4 +20,7 @@
     }
   }
 
+  td.nesting {
+    background: transparent !important;
+  }
 }


### PR DESCRIPTION
When nesting tables within `<td>`, the columns continue to color themselves in behind the nested table. Added a "nesting" class intended to be applied to the parent `<td>` element containing the nested table to indicate that the background should not be applied as it otherwise would.