### PR TITLE
Charts: use `aspect-ratio` instead of calculating `height`

### DIFF
--- a/src/charts/_area.scss
+++ b/src/charts/_area.scss
@@ -11,7 +11,7 @@
       justify-content: space-between;
       align-items: stretch;
       width: 100%;
-      height: calc(100% - var(--#{ $variable-prefix }heading-size));
+      aspect-ratio: 21/9;
 
       tr {
         position: relative;

--- a/src/charts/_bar.scss
+++ b/src/charts/_bar.scss
@@ -11,7 +11,6 @@
       justify-content: space-between;
       align-items: stretch;
       width: 100%;
-      height: calc(100% - var(--#{ $variable-prefix }heading-size));
 
       tr {
         position: relative;
@@ -37,6 +36,8 @@
           align-items: center;
           width: calc(100% * var(--#{ $variable-prefix }end, var(--#{ $variable-prefix }size, 1)));
           height: 100%;
+          padding-block-start: 10px; // BC for pre 1.0.0 versions
+          padding-block-end: 10px; // BC for pre 1.0.0 versions
           position: relative; // For tooltips
         }
 

--- a/src/charts/_column.scss
+++ b/src/charts/_column.scss
@@ -11,7 +11,7 @@
       justify-content: space-between;
       align-items: stretch;
       width: 100%;
-      height: calc(100% - var(--#{ $variable-prefix }heading-size));
+      aspect-ratio: 21/9;
 
       tr {
         position: relative;

--- a/src/charts/_line.scss
+++ b/src/charts/_line.scss
@@ -12,7 +12,7 @@
       justify-content: space-between;
       align-items: stretch;
       width: 100%;
-      height: calc(100% - var(--#{ $variable-prefix }heading-size));
+      aspect-ratio: 21/9;
 
       tr {
         position: relative;

--- a/src/general/_mixins.scss
+++ b/src/general/_mixins.scss
@@ -17,8 +17,7 @@
 @mixin circle {
   display: block;
   width: 100%;
-  height: 0;               // old hack for "aspect-ratio"
-  padding-block-end: 100%; // makes height 100% of the width
+  aspect-ratio: 1;
   border-radius: 50%;
   background-color: var(--#{ $variable-prefix }chart-bg-color);
 }

--- a/src/index.html
+++ b/src/index.html
@@ -81,7 +81,7 @@
 
     <div class="examples bar-charts">
 
-      <table class="charts-css bar show-heading show-data-on-hover show-primary-axis" style="height: 200px;">
+      <table class="charts-css bar show-heading show-data-on-hover show-primary-axis">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -113,7 +113,7 @@
         </tbody>
       </table>
 
-      <table class="charts-css bar show-heading show-data-on-hover show-primary-axis reverse" style="height: 200px;">
+      <table class="charts-css bar show-heading show-data-on-hover show-primary-axis reverse">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -151,7 +151,7 @@
 
     <div class="examples bar-charts">
 
-      <table class="charts-css bar show-labels show-data-on-hover show-primary-axis reverse-data" style="height: 200px;">
+      <table class="charts-css bar show-labels show-data-on-hover show-primary-axis reverse-data">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -183,7 +183,7 @@
         </tbody>
       </table>
 
-      <table class="charts-css bar show-labels show-data-on-hover show-primary-axis reverse-data reverse" style="height: 200px;">
+      <table class="charts-css bar show-labels show-data-on-hover show-primary-axis reverse-data reverse">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -221,7 +221,7 @@
 
     <div class="examples bar-charts">
 
-      <table class="charts-css bar show-labels show-data-on-hover show-primary-axis show-data-axes multiple data-spacing-10" style="height: 350px;">
+      <table class="charts-css bar show-labels show-data-on-hover show-primary-axis show-data-axes multiple data-spacing-10">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -253,7 +253,7 @@
         </tbody>
       </table>
 
-      <table class="charts-css bar show-labels show-data-on-hover show-primary-axis show-data-axes multiple data-spacing-10 reverse" style="height: 350px;">
+      <table class="charts-css bar show-labels show-data-on-hover show-primary-axis show-data-axes multiple data-spacing-10 reverse">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -291,7 +291,7 @@
 
     <div class="examples bar-charts">
 
-      <table class="charts-css bar show-labels show-data-on-hover show-primary-axis show-10-secondary-axes show-data-axes multiple data-spacing-10 reverse-data reverse-datasets" style="height: 350px;">
+      <table class="charts-css bar show-labels show-data-on-hover show-primary-axis show-10-secondary-axes show-data-axes multiple data-spacing-10 reverse-data reverse-datasets">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -323,7 +323,7 @@
         </tbody>
       </table>
 
-      <table class="charts-css bar show-labels show-data-on-hover show-primary-axis show-10-secondary-axes show-data-axes multiple data-spacing-10 reverse-data reverse-datasets reverse" style="height: 350px;">
+      <table class="charts-css bar show-labels show-data-on-hover show-primary-axis show-10-secondary-axes show-data-axes multiple data-spacing-10 reverse-data reverse-datasets reverse">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -361,7 +361,7 @@
 
     <div class="examples bar-charts">
 
-      <table class="charts-css bar show-labels show-data-on-hover show-primary-axis show-10-secondary-axes data-spacing-5 multiple stacked" style="height: 150px;">
+      <table class="charts-css bar show-labels show-data-on-hover show-primary-axis show-10-secondary-axes data-spacing-5 multiple stacked">
         <caption>House Spending by Countries</caption>
         <thead>
           <tr>
@@ -392,7 +392,7 @@
         </tbody>
       </table>
 
-      <table class="charts-css bar show-labels show-data-on-hover show-primary-axis show-10-secondary-axes data-spacing-5 multiple stacked reverse" style="height: 150px;">
+      <table class="charts-css bar show-labels show-data-on-hover show-primary-axis show-10-secondary-axes data-spacing-5 multiple stacked reverse">
         <caption>House Spending by Countries</caption>
         <thead>
           <tr>
@@ -429,7 +429,7 @@
 
     <div class="examples bar-charts">
 
-      <table class="charts-css bar show-labels show-data-on-hover show-primary-axis show-10-secondary-axes data-spacing-5 multiple stacked reverse-datasets" style="height: 150px;">
+      <table class="charts-css bar show-labels show-data-on-hover show-primary-axis show-10-secondary-axes data-spacing-5 multiple stacked reverse-datasets">
         <caption>House Spending by Countries</caption>
         <thead>
           <tr>
@@ -460,7 +460,7 @@
         </tbody>
       </table>
 
-      <table class="charts-css bar show-labels show-data-on-hover show-primary-axis show-10-secondary-axes data-spacing-5 multiple stacked reverse-datasets reverse" style="height: 150px;">
+      <table class="charts-css bar show-labels show-data-on-hover show-primary-axis show-10-secondary-axes data-spacing-5 multiple stacked reverse-datasets reverse">
         <caption>House Spending by Countries</caption>
         <thead>
           <tr>
@@ -508,7 +508,7 @@
 
     <div class="examples column-charts">
 
-      <table class="charts-css column show-heading show-data-on-hover show-primary-axis" style="height: 200px;">
+      <table class="charts-css column show-heading show-data-on-hover show-primary-axis">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -540,7 +540,7 @@
         </tbody>
       </table>
 
-      <table class="charts-css column show-heading show-data-on-hover show-primary-axis reverse" style="height: 200px;">
+      <table class="charts-css column show-heading show-data-on-hover show-primary-axis reverse">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -578,7 +578,7 @@
 
     <div class="examples column-charts">
 
-      <table class="charts-css column show-labels show-data-on-hover show-primary-axis reverse-data" style="height: 200px;">
+      <table class="charts-css column show-labels show-data-on-hover show-primary-axis reverse-data">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -610,7 +610,7 @@
         </tbody>
       </table>
 
-      <table class="charts-css column show-labels show-data-on-hover show-primary-axis reverse-data reverse" style="height: 200px;">
+      <table class="charts-css column show-labels show-data-on-hover show-primary-axis reverse-data reverse">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -648,7 +648,7 @@
 
     <div class="examples column-charts">
 
-      <table class="charts-css column show-labels show-data-on-hover show-primary-axis show-data-axes multiple data-spacing-10" style="height: 200px;">
+      <table class="charts-css column show-labels show-data-on-hover show-primary-axis show-data-axes multiple data-spacing-10">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -680,7 +680,7 @@
         </tbody>
       </table>
 
-      <table class="charts-css column show-labels show-data-on-hover show-primary-axis show-data-axes multiple data-spacing-10 reverse" style="height: 200px;">
+      <table class="charts-css column show-labels show-data-on-hover show-primary-axis show-data-axes multiple data-spacing-10 reverse">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -718,7 +718,7 @@
 
     <div class="examples column-charts">
 
-      <table class="charts-css column show-labels show-data-on-hover show-primary-axis show-10-secondary-axes show-data-axes multiple data-spacing-10 reverse-data reverse-datasets" style="height: 200px;">
+      <table class="charts-css column show-labels show-data-on-hover show-primary-axis show-10-secondary-axes show-data-axes multiple data-spacing-10 reverse-data reverse-datasets">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -750,7 +750,7 @@
         </tbody>
       </table>
 
-      <table class="charts-css column show-labels show-data-on-hover show-primary-axis show-10-secondary-axes show-data-axes multiple data-spacing-10 reverse-data reverse-datasets reverse" style="height: 200px;">
+      <table class="charts-css column show-labels show-data-on-hover show-primary-axis show-10-secondary-axes show-data-axes multiple data-spacing-10 reverse-data reverse-datasets reverse">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -788,7 +788,7 @@
 
     <div class="examples column-charts">
 
-      <table class="charts-css column show-labels show-data-on-hover show-primary-axis show-10-secondary-axes data-spacing-5 multiple stacked" style="height: 200px;">
+      <table class="charts-css column show-labels show-data-on-hover show-primary-axis show-10-secondary-axes data-spacing-5 multiple stacked">
         <caption>House Spending by Countries</caption>
         <thead>
           <tr>
@@ -819,7 +819,7 @@
         </tbody>
       </table>
 
-      <table class="charts-css column show-labels show-data-on-hover show-primary-axis show-10-secondary-axes data-spacing-5 multiple stacked reverse" style="height: 200px;">
+      <table class="charts-css column show-labels show-data-on-hover show-primary-axis show-10-secondary-axes data-spacing-5 multiple stacked reverse">
         <caption>House Spending by Countries</caption>
         <thead>
           <tr>
@@ -856,7 +856,7 @@
 
     <div class="examples column-charts">
 
-      <table class="charts-css column show-labels show-data-on-hover show-primary-axis show-10-secondary-axes data-spacing-5 multiple stacked reverse-datasets" style="height: 200px;">
+      <table class="charts-css column show-labels show-data-on-hover show-primary-axis show-10-secondary-axes data-spacing-5 multiple stacked reverse-datasets">
         <caption>House Spending by Countries</caption>
         <thead>
           <tr>
@@ -887,7 +887,7 @@
         </tbody>
       </table>
 
-      <table class="charts-css column show-labels show-data-on-hover show-primary-axis show-10-secondary-axes data-spacing-5 multiple stacked reverse-datasets reverse" style="height: 200px;">
+      <table class="charts-css column show-labels show-data-on-hover show-primary-axis show-10-secondary-axes data-spacing-5 multiple stacked reverse-datasets reverse">
         <caption>House Spending by Countries</caption>
         <thead>
           <tr>
@@ -935,7 +935,7 @@
 
     <div class="examples area-charts">
 
-      <table class="charts-css area show-heading show-labels show-data-on-hover show-primary-axis show-data-axes show-1-secondary-axes" style="height: 200px;">
+      <table class="charts-css area show-heading show-labels show-data-on-hover show-primary-axis show-data-axes show-1-secondary-axes">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -967,7 +967,7 @@
         </tbody>
       </table>
 
-      <table class="charts-css area show-heading show-labels show-data-on-hover show-primary-axis show-data-axes show-1-secondary-axes reverse" style="height: 200px;">
+      <table class="charts-css area show-heading show-labels show-data-on-hover show-primary-axis show-data-axes show-1-secondary-axes reverse">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -1005,7 +1005,7 @@
 
     <div class="examples area-charts">
 
-      <table class="charts-css area show-labels show-data-on-hover show-primary-axis reverse-data" style="height: 200px;">
+      <table class="charts-css area show-labels show-data-on-hover show-primary-axis reverse-data">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -1037,7 +1037,7 @@
         </tbody>
       </table>
 
-      <table class="charts-css area show-labels show-data-on-hover show-primary-axis reverse-data reverse" style="height: 200px;">
+      <table class="charts-css area show-labels show-data-on-hover show-primary-axis reverse-data reverse">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -1075,7 +1075,7 @@
 
     <div class="examples area-charts">
 
-      <table class="charts-css area show-labels show-data-on-hover show-primary-axis show-data-axes multiple" style="height: 200px;">
+      <table class="charts-css area show-labels show-data-on-hover show-primary-axis show-data-axes multiple">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -1107,7 +1107,7 @@
         </tbody>
       </table>
 
-      <table class="charts-css area show-labels show-data-on-hover show-primary-axis show-data-axes multiple reverse" style="height: 200px;">
+      <table class="charts-css area show-labels show-data-on-hover show-primary-axis show-data-axes multiple reverse">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -1145,7 +1145,7 @@
 
     <div class="examples area-charts">
 
-      <table class="charts-css area show-labels show-data-on-hover show-primary-axis show-10-secondary-axes show-data-axes multiple reverse-data reverse-datasets" style="height: 200px;">
+      <table class="charts-css area show-labels show-data-on-hover show-primary-axis show-10-secondary-axes show-data-axes multiple reverse-data reverse-datasets">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -1177,7 +1177,7 @@
         </tbody>
       </table>
 
-      <table class="charts-css area show-labels show-data-on-hover show-primary-axis show-10-secondary-axes show-data-axes multiple reverse-data reverse-datasets reverse" style="height: 200px;">
+      <table class="charts-css area show-labels show-data-on-hover show-primary-axis show-10-secondary-axes show-data-axes multiple reverse-data reverse-datasets reverse">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -1226,7 +1226,7 @@
 
     <div class="examples line-charts">
 
-      <table class="charts-css line show-heading show-labels show-data-on-hover show-primary-axis show-data-axes show-10-secondary-axes" style="height: 200px;">
+      <table class="charts-css line show-heading show-labels show-data-on-hover show-primary-axis show-data-axes show-10-secondary-axes">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -1258,7 +1258,7 @@
         </tbody>
       </table>
 
-      <table class="charts-css line show-heading show-labels show-data-on-hover show-primary-axis show-data-axes show-10-secondary-axes reverse" style="height: 200px;">
+      <table class="charts-css line show-heading show-labels show-data-on-hover show-primary-axis show-data-axes show-10-secondary-axes reverse">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -1296,7 +1296,7 @@
 
     <div class="examples line-charts">
 
-      <table class="charts-css line show-labels show-data-on-hover show-primary-axis reverse-data" style="height: 200px;">
+      <table class="charts-css line show-labels show-data-on-hover show-primary-axis reverse-data">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -1328,7 +1328,7 @@
         </tbody>
       </table>
 
-      <table class="charts-css line show-labels show-data-on-hover show-primary-axis reverse-data reverse" style="height: 200px;">
+      <table class="charts-css line show-labels show-data-on-hover show-primary-axis reverse-data reverse">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -1366,7 +1366,7 @@
 
     <div class="examples line-charts">
 
-      <table class="charts-css line show-labels show-data-on-hover show-primary-axis show-data-axes multiple" style="height: 200px;">
+      <table class="charts-css line show-labels show-data-on-hover show-primary-axis show-data-axes multiple">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -1398,7 +1398,7 @@
         </tbody>
       </table>
 
-      <table class="charts-css line show-labels show-data-on-hover show-primary-axis show-data-axes multiple reverse" style="height: 200px;">
+      <table class="charts-css line show-labels show-data-on-hover show-primary-axis show-data-axes multiple reverse">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -1436,7 +1436,7 @@
 
     <div class="examples line-charts">
 
-      <table class="charts-css line show-labels show-data-on-hover show-primary-axis show-10-secondary-axes show-data-axes multiple reverse-data reverse-datasets" style="height: 200px;">
+      <table class="charts-css line show-labels show-data-on-hover show-primary-axis show-10-secondary-axes show-data-axes multiple reverse-data reverse-datasets">
         <caption>Years Compared</caption>
         <thead>
           <tr>
@@ -1468,7 +1468,7 @@
         </tbody>
       </table>
 
-      <table class="charts-css line show-labels show-data-on-hover show-primary-axis show-10-secondary-axes show-data-axes multiple reverse-data reverse-datasets reverse" style="height: 200px;">
+      <table class="charts-css line show-labels show-data-on-hover show-primary-axis show-10-secondary-axes show-data-axes multiple reverse-data reverse-datasets reverse">
         <caption>Years Compared</caption>
         <thead>
           <tr>


### PR DESCRIPTION
To avoid setting `height` for each chart, each chart should have a default `aspect-ratio`.

This change aims to simplify the usage, without requiring any custom CSS.