### PR TITLE
Heading: deprecate `--heading-size` css variable

### DIFF
--- a/src/components/_heading.scss
+++ b/src/components/_heading.scss
@@ -11,12 +11,10 @@
   }
 
   &.show-heading {
-    --#{ $variable-prefix }heading-size: 1.5rem;
 
     caption {
       display: block;
       width: 100%;
-      height: var(--#{ $variable-prefix }heading-size);
     }
 
   }

--- a/src/components/_wrapper.scss
+++ b/src/components/_wrapper.scss
@@ -10,9 +10,6 @@
   // General Colors
   --#{ $variable-prefix }chart-bg-color: rgb(245 245 245);
 
-  // Heading
-  --#{ $variable-prefix }heading-size: 0px; // Unit required
-
   // Axes
   --#{ $variable-prefix }primary-axis-color: rgba(0 0 0 / 100%);
   --#{ $variable-prefix }primary-axis-style: solid;

--- a/src/general/_properties.scss
+++ b/src/general/_properties.scss
@@ -17,11 +17,6 @@ $color-vars: color, chart-bg-color;
   }
 }
 
-// Heading
-@property --#{ $variable-prefix }heading-size {
-  @include at-property( "<length>", 0, true );
-}
-
 // Labels
 @property --#{ $variable-prefix }labels-size {
   @include at-property( "<length>", 0, true );


### PR DESCRIPTION
Now that charts use default `aspect-ratio` instead of calculating `height`, we no longer need the `--heading-size` CSS variable as the aspect ratio is applied on `tbody` therefore `caption` height is no longer needed for the calculation.