### PR TITLE
Bar Chart: Set min height for each `<td>`

### DIFF
--- a/src/charts/_bar.scss
+++ b/src/charts/_bar.scss
@@ -36,6 +36,7 @@
           align-items: center;
           width: calc(100% * var(--#{ $variable-prefix }end, var(--#{ $variable-prefix }size, 1)));
           height: 100%;
+          min-height: 1rem;
           padding-block-start: 10px; // BC for pre 1.0.0 versions
           padding-block-end: 10px; // BC for pre 1.0.0 versions
           position: relative; // For tooltips


### PR DESCRIPTION
Fixes an issue when using only `hide-data`, the table becomes not visible.