### PR TITLE
docs: specify version in CDN URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ Check the full documentation on [ChartsCSS.org](https://ChartsCSS.org/).
 Use [jsdelivr](https://www.jsdelivr.com/package/npm/charts.css) CDN:
 
 ```html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/charts.css/dist/charts.min.css">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/charts.css@1/dist/charts.min.css">
 ```
 
 Or [unpkg](https://unpkg.com/browse/charts.css/) CDN:
 
 ```html
-<link rel="stylesheet" href="https://unpkg.com/charts.css/dist/charts.min.css">
+<link rel="stylesheet" href="https://unpkg.com/charts.css@^1/dist/charts.min.css">
 ```
 
 ### Package Manager


### PR DESCRIPTION
Both CDN supports semver in the URL.

Specifying v1 is advised to avoid unexpected breaking changes.

---

> use a version range instead of a specific version

```
https://cdn.jsdelivr.net/npm/jquery@3.6/dist/jquery.min.js
https://cdn.jsdelivr.net/npm/jquery@3/dist/jquery.min.js
```

> omit the version completely to get the latest one. **you should NOT use this in production**

```
https://cdn.jsdelivr.net/npm/jquery/dist/jquery.min.js
```

> You may also use a [semver range](https://docs.npmjs.com/misc/semver) or a [tag](https://docs.npmjs.com/cli/dist-tag) instead of a fixed version number, or omit the version/tag entirely to use the latest tag.

```
https://unpkg.com/react@^16/umd/react.production.min.js
```