### PR TITLE
place tooltip above line of line chart, otherwise fall back to default

### DIFF
--- a/src/components/_tooltips.scss
+++ b/src/components/_tooltips.scss
@@ -7,8 +7,13 @@
     // Position
     position: absolute;
     z-index: 1;
-    inset-block-end: 50%;
+    // if --start / --end exist, then it's a line chart, and we calculate
+    // the larger of the two to place the tooltip above the line segment;
+    // if --start and --end don't exist, fallback to 0.5 * 100% = 50%,
+    // which is the default tooltip position for e.g. bar charts
+    inset-block-end: calc(max(var(--start, 0.5), var(--end, 0.5)) * 100%);
     inset-inline-start: 50%;
+    transform: translateX(-50%); // translateX for both bar & column chart
     width: max-content;
     padding: 5px 10px;
     border-radius: 6px;

--- a/src/components/_tooltips.scss
+++ b/src/components/_tooltips.scss
@@ -13,7 +13,6 @@
     // which is the default tooltip position for e.g. bar charts
     inset-block-end: calc(max(var(--start, 0.5), var(--end, 0.5)) * 100%);
     inset-inline-start: 50%;
-    transform: translateX(-50%); // translateX for both bar & column chart
     width: max-content;
     padding: 5px 10px;
     border-radius: 6px;


### PR DESCRIPTION
Thanks for the great library!

I was trying to think of ways of positioning the tooltip in a more convenient place when in line charts, as the default positioning is always 50%; depending on the actual chart, this may not be ideal:

<img width="363" alt="Screenshot 2024-05-01 at 21 53 16" src="https://github.com/ChartsCSS/charts.css/assets/52645/0ffc3d72-bea1-4176-a8ba-4dac695f2e94">

(the line chart/tooltip interaction in Firefox also has some rendering problems, as you can see chart segments to the right of the tooltip render "over" the tooltip, but that is a separate issue!)

In this PR, I suggest to use `calc()` to calculate the maximum of `--start` and `--end` variables, and multiply it by `100%`, to change the tooltip position so that it always renders _above_ the line:

<img width="356" alt="Screenshot 2024-05-01 at 21 52 59" src="https://github.com/ChartsCSS/charts.css/assets/52645/a2da53d1-2ef3-48bb-aaeb-f5ff01c250a4">

It might need a bit more padding, as you can see the "tail" of the tooltip is just slightly below the line segment still, but, I believe it is an improvement.

Also, using `var()`'s second parameter, the fallback parameter, we can fall back to using a value of `0.5 * 100%` = `50%`, which is the default (current) value today. In this way, I don't think this change should affect chart types other than line charts.