### PR TITLE
chore: update ci publish code

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20.x"
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
-      - run: npm publish --provenance --access public
+      - run: npm publish --force --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,24 +1,21 @@
-name: "Publish Package"
+name: Publish Package to npmjs
 
 on:
   release:
     types: [published]
 
 jobs:
-  release:
-    name: publish
+  publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org
-
-      - name: Publish to npm
-        run: npm publish --access public
+          node-version: "20.x"
+          registry-url: "https://registry.npmjs.org"
+      - run: npm publish --provenance --access public
         env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.37.1",
+        "@types/node": "^22.18.6",
         "autoprefixer": "^10.4.14",
         "browserslist-config-baseline": "^0.4.0",
         "cssnano": "^6.0.1",
@@ -226,10 +227,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.0.tgz",
-      "integrity": "sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q==",
-      "dev": true
+      "version": "22.18.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.6.tgz",
+      "integrity": "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -4235,6 +4240,13 @@
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
       "dev": true
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/universalify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
@@ -4585,10 +4597,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "20.5.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.0.tgz",
-      "integrity": "sha512-Mgq7eCtoTjT89FqNoTzzXg2XvCi5VMhRV6+I2aYanc6kQCBImeNaAYRs/DyoVqk1YEUJK5gN9VO7HRIdz4Wo3Q==",
-      "dev": true
+      "version": "22.18.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.6.tgz",
+      "integrity": "sha512-r8uszLPpeIWbNKtvWRt/DbVi5zbqZyj1PTmhRMqBMvDnaz1QpmSKujUtJLrqGZeoM8v72MfYggDceY4K1itzWQ==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",
@@ -7417,6 +7432,12 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "test": "npm-run-all build test:copy-css test:run",
     "test:copy-css": "postcss dist/charts.min.css --use postcss-pseudo-element-colons --no-map --output tests/playwright/charts.min.css",
     "test:snapshots": "playwright test --update-snapshots --trace off",
-    "test:run": "playwright test -c tests/playwright.config.ts"
+    "test:run": "playwright test -c tests/playwright.config.ts",
+    "prepublishOnly": "node prepublish"
   },
   "repository": {
     "type": "git",
@@ -44,6 +45,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.37.1",
+    "@types/node": "^22.18.6",
     "autoprefixer": "^10.4.14",
     "browserslist-config-baseline": "^0.4.0",
     "cssnano": "^6.0.1",

--- a/prepublish.js
+++ b/prepublish.js
@@ -1,0 +1,6 @@
+import { writeFileSync } from 'node:fs';
+import _pkg from './package.json' with { type: 'json' };
+
+const { browserslist, ...pkg } = _pkg;
+
+writeFileSync('./package.json', JSON.stringify(pkg, null, '  ') + '\n');


### PR DESCRIPTION
Fixes https://github.com/ChartsCSS/charts.css/issues/145

- GitHub Action uses Node.js 22 LTS
- [Provenance statements](https://docs.npmjs.com/generating-provenance-statements) are generated
- `package.json`'s `browserlist` key is deleted on pre-publish