### PR TITLE
Measure and document compressed sizes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -84,6 +84,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -125,6 +126,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -764,6 +766,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2700,6 +2703,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.5.tgz",
       "integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -3227,6 +3231,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3978,6 +3983,7 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
       "integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -4785,6 +4791,7 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.5",
         "@csstools/css-syntax-patches-for-csstree": "^1.0.19",
@@ -5111,6 +5118,7 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -21,11 +21,12 @@
     "dist/charts.min.css"
   ],
   "scripts": {
-    "build": "npm-run-all update-browserslist css-compile css-selectors-merge css-minify css-minify-fix test:copy-css",
+    "build": "npm-run-all update-browserslist css-compile css-selectors-merge css-minify css-minify-fix test:copy-css css-sizes",
     "css-compile": "sass --style=expanded src/charts.scss:dist/charts.css",
     "css-selectors-merge": "postcss dist/charts.css --use postcss-merge-selectors --output dist/charts.css",
     "css-minify": "postcss dist/charts.css --use cssnano --no-map --output dist/charts.min.css",
     "css-minify-fix": "postcss dist/charts.min.css --use postcss-pseudo-element-colons --no-map --output dist/charts.min.css",
+    "css-sizes": "echo \"Raw: $(wc -c < dist/charts.min.css) bytes\" && echo \"Gzip: $(gzip -c dist/charts.min.css | wc -c) bytes\" && echo \"Brotli: $(brotli -c dist/charts.min.css | wc -c) bytes\"",
     "watch": "nodemon -e scss,html --watch src --exec \"npm run build\"",
     "scss-lint": "stylelint \"**/*.scss\"",
     "update-browserslist": "npx update-browserslist-db@latest",


### PR DESCRIPTION
Add a css-sizes npm script that reports raw, gzip, and brotli sizes after build, making regressions visible.